### PR TITLE
fix keyword-comparison token at the beginning of a string

### DIFF
--- a/examples/packer.pkr.hcl
+++ b/examples/packer.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    happycloud = {
+      version = ">= 2.7.0"
+      source = "github.com/hashicorp/happycloud"
+    }
+  }
+}

--- a/grammars/packer.yaml
+++ b/grammars/packer.yaml
@@ -307,7 +307,7 @@ repository:
     match: '\?|:'
     name: keyword.operator.ternary.packer
   keyword-comparison:
-    match: ~>|>=|<=|==|!=|[^<]<[^<]|[^>]>[^>]
+    match: ~>|>=|<=|==|!=|[^<"]<[^<"]|[^>"]>[^>"]
     name: keyword.operator.comparison.packer
   keyword-conditional:
     match: \b(if|else|endif)\b


### PR DESCRIPTION
The keyword-comparison regular expression consumes the double quotes from the beginning of the string. This generated issues like https://github.com/4ops/vscode-language-packer/issues/9

I fixed this by adding the double quotes to the list of characters that must not be present