### PR TITLE
Fix highlighting greater/smaller than following double quotes

### DIFF
--- a/grammars/packer.yaml
+++ b/grammars/packer.yaml
@@ -307,7 +307,7 @@ repository:
     match: '\?|:'
     name: keyword.operator.ternary.packer
   keyword-comparison:
-    match: ~>|>=|<=|==|!=|[^<"]<[^<"]|[^>"]>[^>"]
+    match: ~>|>=|<=|==|!=|(?<![<"])(<)(?![<"])|(?<![>"])(>)(?![>"])
     name: keyword.operator.comparison.packer
   keyword-conditional:
     match: \b(if|else|endif)\b


### PR DESCRIPTION
An example is the `">` in the following line
```
    qemu   = { source = "github.com/hashicorp/qemu",   version = ">= 1.1.0" }
```